### PR TITLE
Last fixups before release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+1.0.0: 2017-12-14
+-----------------
+
+- Fork project to requests-gssapi
+- Replace pykerberos with python-gssapi
+- Add HTTPSPNEGOAuth interface.  HTTPKerberosAuth is retained as a shim, but
+  bump the major version anyway for clarity.
+
 0.11.0: 2016-11-02
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,8 @@ applicable). However, an explicit credential can be in instead, if desired.
     >>> import gssapi
     >>> import requests
     >>> from requests_gssapi import HTTPSPNEGOAuth, REQUIRED
-    >>> creds = gssapi.Credentials(name=gssapi.Name("user@REALM"), usage="initiate")
+    >>> name = gssapi.Name("user@REALM", gssapi.NameType.hostbased_service)
+    >>> creds = gssapi.Credentials(name=name, usage="initiate")
     >>> gssapi_auth = HTTPSPNEGOAuth(creds=creds)
     >>> r = requests.get("http://example.org", auth=gssapi_auth)
     ...

--- a/requests_gssapi/__init__.py
+++ b/requests_gssapi/__init__.py
@@ -22,4 +22,4 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 __all__ = ('HTTPSPNEGOAuth', 'HTTPKerberosAuth', 'MutualAuthenticationError',
            'REQUIRED', 'OPTIONAL', 'DISABLED')
-__version__ = '0.11.0'
+__version__ = '1.0.0'

--- a/requests_gssapi/compat.py
+++ b/requests_gssapi/compat.py
@@ -45,7 +45,8 @@ class HTTPKerberosAuth(HTTPSPNEGOAuth):
         try:
             if self.principal is not None:
                 gss_stage = "acquiring credentials"
-                name = gssapi.Name(self.principal)
+                name = gssapi.Name(
+                    self.principal, gssapi.NameType.hostbased_service)
                 self.creds = gssapi.Credentials(name=name, usage="initiate")
 
             # contexts still need to be stored by host, but hostname_override
@@ -59,7 +60,8 @@ class HTTPKerberosAuth(HTTPSPNEGOAuth):
                     kerb_host = self.hostname_override
 
                 kerb_spn = "{0}@{1}".format(self.service, kerb_host)
-                self.target_name = gssapi.Name(kerb_spn)
+                self.target_name = gssapi.Name(
+                    kerb_spn, gssapi.NameType.hostbased_service)
 
             return HTTPSPNEGOAuth.generate_request_header(self, response,
                                                           host, is_preemptive)

--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -1,6 +1,8 @@
 import re
 import logging
 
+from base64 import b64encode, b64decode
+
 import gssapi
 
 from requests.auth import AuthBase
@@ -73,7 +75,7 @@ def _negotiate_value(response):
     if authreq:
         match_obj = regex.search(authreq)
         if match_obj:
-            return match_obj.group(1)
+            return b64decode(match_obj.group(1))
 
     return None
 
@@ -144,7 +146,7 @@ class HTTPSPNEGOAuth(AuthBase):
                 gss_response = self.context[host].step(
                     _negotiate_value(response))
 
-            return "Negotiate {0}".format(gss_response)
+            return "Negotiate {0}".format(b64encode(gss_response).decode())
 
         except gssapi.exceptions.GSSError as error:
             msg = error.gen_message()

--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -134,7 +134,8 @@ class HTTPSPNEGOAuth(AuthBase):
                 if '@' not in self.target_name:
                     self.target_name = "%s@%s" % (self.target_name, host)
 
-                self.target_name = gssapi.Name(self.target_name)
+                self.target_name = gssapi.Name(
+                    self.target_name, gssapi.NameType.hostbased_service)
             self.context[host] = gssapi.SecurityContext(
                 usage="initiate", flags=gssflags, name=self.target_name,
                 creds=self.creds)

--- a/test_requests_gssapi.py
+++ b/test_requests_gssapi.py
@@ -37,6 +37,10 @@ b64_negotiate_token = "negotiate " + b64encode(b"token").decode()
 b64_negotiate_server = "negotiate " + b64encode(b"servertoken").decode()
 
 
+def gssapi_name(s):
+    return gssapi.Name(s, gssapi.NameType.hostbased_service)
+
+
 class GSSAPITestCase(unittest.TestCase):
     def setUp(self):
         """Setup."""
@@ -99,7 +103,7 @@ class GSSAPITestCase(unittest.TestCase):
                 auth.generate_request_header(response, host),
                 b64_negotiate_response)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 creds=None, flags=gssflags, usage="initiate")
             fake_resp.assert_called_with(b"token")
 
@@ -114,7 +118,7 @@ class GSSAPITestCase(unittest.TestCase):
             self.assertRaises(requests_gssapi.exceptions.SPNEGOExchangeError,
                               auth.generate_request_header, response, host)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=None)
 
     def test_generate_request_header_step_error(self):
@@ -128,7 +132,7 @@ class GSSAPITestCase(unittest.TestCase):
             self.assertRaises(requests_gssapi.exceptions.SPNEGOExchangeError,
                               auth.generate_request_header, response, host)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fail_resp.assert_called_with(b"token")
 
@@ -165,7 +169,7 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 flags=gssflags, usage="initiate", creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -202,7 +206,7 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 creds=None, flags=gssflags, usage="initiate")
             fake_resp.assert_called_with(b"token")
 
@@ -436,7 +440,7 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -479,7 +483,7 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -493,7 +497,7 @@ class GSSAPITestCase(unittest.TestCase):
             auth = requests_gssapi.HTTPKerberosAuth(service="barfoo")
             auth.generate_request_header(response, host),
             fake_init.assert_called_with(
-                name=gssapi.Name("barfoo@www.example.org"),
+                name=gssapi_name("barfoo@www.example.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -530,7 +534,7 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssdelegflags, creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -546,11 +550,10 @@ class GSSAPITestCase(unittest.TestCase):
             auth.generate_request_header(response, host)
             fake_creds.assert_called_with(gssapi.creds.Credentials,
                                           usage="initiate",
-                                          name=gssapi.Name("user@REALM"))
+                                          name=gssapi_name("user@REALM"))
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=b"fake creds")
-            fake_resp.assert_called_with(b"token")
 
     def test_realm_override(self):
         with patch.multiple("gssapi.SecurityContext", __init__=fake_init,
@@ -563,7 +566,7 @@ class GSSAPITestCase(unittest.TestCase):
                 hostname_override="otherhost.otherdomain.org")
             auth.generate_request_header(response, host)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@otherhost.otherdomain.org"),
+                name=gssapi_name("HTTP@otherhost.otherdomain.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fake_resp.assert_called_with(b"token")
 
@@ -592,7 +595,7 @@ class GSSAPITestCase(unittest.TestCase):
             auth = requests_gssapi.HTTPSPNEGOAuth(creds=creds)
             auth.generate_request_header(response, host)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@www.example.org"),
+                name=gssapi_name("HTTP@www.example.org"),
                 usage="initiate", flags=gssflags, creds=b"fake creds")
             fake_resp.assert_called_with(b"token")
 
@@ -607,7 +610,7 @@ class GSSAPITestCase(unittest.TestCase):
                 target_name="HTTP@otherhost.otherdomain.org")
             auth.generate_request_header(response, host)
             fake_init.assert_called_with(
-                name=gssapi.Name("HTTP@otherhost.otherdomain.org"),
+                name=gssapi_name("HTTP@otherhost.otherdomain.org"),
                 usage="initiate", flags=gssflags, creds=None)
             fake_resp.assert_called_with(b"token")
 


### PR DESCRIPTION
These were encountered when running the [mod_auth_gssapi](https://github.com/modauthgssapi/mod_auth_gssapi) test suite against the shim interface.  I replaced all `import requests_kerberos` there with `import requests_gssapi` and performed no other action, so it tested only the shim interface.  It may be good to add a CI item for doing this on a regular basis going forward.

Also this is the last thing on my TODO list before release.