### PR TITLE
Makefile with srpm target for corp.

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,4 @@
+srpm:
+	dnf install -y python2
+	sed "s/name='requests-gssapi'/name='python-requests-gssapi'/" setup.py > .copr/setup.py
+	python .copr/setup.py bdist_rpm --source-only --dist-dir "$(outdir)" --build-requires=python-setuptools


### PR DESCRIPTION
https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm

I understand changing the `name` in `setup.py` is not the right way to do it but I did not find a mechanism to override the `name` in `bdist_rpm` invocation.

Providing here as an example of how the package can be easily buildable in copr: https://copr.fedorainfracloud.org/coprs/adelton/custodia/build/701836/