### PR TITLE
Mutual auth updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,26 @@ the 401 response.
 Mutual Authentication
 ---------------------
 
+Mutual authentication is a poorly-named feature of the GSSAPI which doesn't
+provide any additional security benefit to most possible uses of
+requests_gssapi.  Practically speaking, in most mechanism implementations
+(including krb5), it requires another round-trip between the client and server
+during the authentication handshake.  Many clients and servers do not properly
+handle the authentication handshake taking more than one round-trip.  If you
+encounter a MutualAuthenticationError, this is probably why.
+
+So long as you're running over a TLS link whose security guarantees you trust,
+there's no benefit to mutual authentication.  If you don't trust the link at
+all, mutual authentication won't help (since it's not tamper-proof, and GSSAPI
+isn't being used post-authentication.  There's some middle ground between the
+two where it helps a small amount (e.g., passive adversary over
+encrypted-but-unverified channel), but for Negotiate (what we're doing here),
+it's not generally helpful.
+
+For a more technical explanation of what mutual authentication actually
+guarantees, I refer you to rfc2743 (GSSAPIv2), rfc4120 (krb5 in GSSAPI),
+rfc4178 (SPNEGO), and rfc4559 (HTTP Negotiate).
+
 REQUIRED
 ^^^^^^^^
 

--- a/requests_gssapi/compat.py
+++ b/requests_gssapi/compat.py
@@ -5,7 +5,7 @@ import sys
 
 import gssapi
 
-from .gssapi_ import REQUIRED, HTTPSPNEGOAuth, SPNEGOExchangeError, log
+from .gssapi_ import DISABLED, HTTPSPNEGOAuth, SPNEGOExchangeError, log
 
 # python 2.7 introduced a NullHandler which we want to use, but to support
 # older versions, we implement our own if needed.
@@ -21,7 +21,7 @@ else:
 
 class HTTPKerberosAuth(HTTPSPNEGOAuth):
     """Deprecated compat shim; see HTTPSPNEGOAuth instead."""
-    def __init__(self, mutual_authentication=REQUIRED, service="HTTP",
+    def __init__(self, mutual_authentication=DISABLED, service="HTTP",
                  delegate=False, force_preemptive=False, principal=None,
                  hostname_override=None, sanitize_mutual_error_response=True):
         # put these here for later

--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -84,8 +84,8 @@ class HTTPSPNEGOAuth(AuthBase):
     """Attaches HTTP GSSAPI Authentication to the given Request object.
 
     `mutual_authentication` controls whether GSSAPI should attempt mutual
-    authentication.  It may be `REQUIRED` (default), `OPTIONAL`, or
-    `DISABLED`.
+    authentication.  It may be `REQUIRED`, `OPTIONAL`, or `DISABLED`
+    (default).
 
     `target_name` specifies the remote principal name.  It may be either a
     GSSAPI name type or a string (default: "HTTP" at the DNS host).
@@ -101,8 +101,9 @@ class HTTPSPNEGOAuth(AuthBase):
 
     `sanitize_mutual_error_response` controls whether we should clean up
     server responses.  See the `SanitizedResponse` class.
+
     """
-    def __init__(self, mutual_authentication=REQUIRED, target_name="HTTP",
+    def __init__(self, mutual_authentication=DISABLED, target_name="HTTP",
                  delegate=False, opportunistic_auth=False, creds=None,
                  sanitize_mutual_error_response=True):
         self.context = {}
@@ -123,10 +124,11 @@ class HTTPSPNEGOAuth(AuthBase):
 
         """
 
-        gssflags = [gssapi.RequirementFlag.mutual_authentication,
-                    gssapi.RequirementFlag.out_of_sequence_detection]
+        gssflags = [gssapi.RequirementFlag.out_of_sequence_detection]
         if self.delegate:
             gssflags.append(gssapi.RequirementFlag.delegate_to_peer)
+        if self.mutual_authentication != DISABLED:
+            gssflags.append(gssapi.RequirementFlag.mutual_authentication)
 
         try:
             gss_stage = "initiating context"


### PR DESCRIPTION
Add documentation on MutualAuthenticationError, and disable mutual authentication by default since it buys us basically nothing.

@ktdreyer If you want to take a look at this, that would be great.  Should resolve #15.