### PR TITLE
Add support for specifing an explicit GSSAPI mech

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,27 @@ applicable). However, an explicit credential can be in instead, if desired.
     >>> r = requests.get("http://example.org", auth=gssapi_auth)
     ...
 
+Explicit Mechanism
+------------------
+
+``HTTPSPNEGOAuth`` normally lets the underlying ``gssapi`` library decide which
+negotiation mechanism to use. However, an explicit mechanism can be used instead
+if desired. The ``mech`` parameter will be passed straight through to ``gssapi``
+without interference. It is expected to be an instance of ``gssapi.mechs.Mechanism``.
+
+.. code-block:: python
+
+    >>> import gssapi
+    >>> import requests
+    >>> from requests_gssapi import HTTPSPNEGOAuth
+    >>> try:
+    ...   spnego = gssapi,mechs.Mechanism.from_sasl_name("SPNEGO")
+    ... except AttributeError:
+    ...   spnego = gssapi.OID.from_int_seq("1.3.6.1.5.5.2")
+    >>> gssapi_auth = HTTPSPNEGOAuth(mech=spnego)
+    >>> r = requests.get("http://example.org", auth=gssapi_auth)
+    ...
+
 Delegation
 ----------
 

--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -99,13 +99,16 @@ class HTTPSPNEGOAuth(AuthBase):
     `creds` is GSSAPI credentials (gssapi.Credentials) to use for negotiation.
     Default is `None`.
 
+    `mech` is GSSAPI Mechanism (gssapi.Mechanism) to use for negotiation.
+    Default is `None`
+
     `sanitize_mutual_error_response` controls whether we should clean up
     server responses.  See the `SanitizedResponse` class.
 
     """
     def __init__(self, mutual_authentication=DISABLED, target_name="HTTP",
                  delegate=False, opportunistic_auth=False, creds=None,
-                 sanitize_mutual_error_response=True):
+                 mech=None, sanitize_mutual_error_response=True):
         self.context = {}
         self.pos = None
         self.mutual_authentication = mutual_authentication
@@ -113,6 +116,7 @@ class HTTPSPNEGOAuth(AuthBase):
         self.delegate = delegate
         self.opportunistic_auth = opportunistic_auth
         self.creds = creds
+        self.mech = mech
         self.sanitize_mutual_error_response = sanitize_mutual_error_response
 
     def generate_request_header(self, response, host, is_preemptive=False):
@@ -140,7 +144,7 @@ class HTTPSPNEGOAuth(AuthBase):
                     self.target_name, gssapi.NameType.hostbased_service)
             self.context[host] = gssapi.SecurityContext(
                 usage="initiate", flags=gssflags, name=self.target_name,
-                creds=self.creds)
+                creds=self.creds, mech=self.mech)
 
             gss_stage = "stepping context"
             if is_preemptive:


### PR DESCRIPTION
Add support for passing an explicit mech through to gssapi's
`SecurityContext` constructor. This allows overriding the auto-detected
mechanism, and enabling support for RFC4178 SPNEGO.

Fixes #18