### PR TITLE
Drop out of sequence detection (#38)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 
 FUTURE: TBD
 -----------
+- Drop flag for out of sequence detection
 
 1.2.3: 2021-02-08
 -----------------

--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -129,7 +129,7 @@ class HTTPSPNEGOAuth(AuthBase):
 
         """
 
-        gssflags = [gssapi.RequirementFlag.out_of_sequence_detection]
+        gssflags = []
         if self.delegate:
             gssflags.append(gssapi.RequirementFlag.delegate_to_peer)
         if self.mutual_authentication != DISABLED:

--- a/test_requests_gssapi.py
+++ b/test_requests_gssapi.py
@@ -28,7 +28,7 @@ fake_resp = Mock(return_value=b"GSSRESPONSE")
 # construction, so construct a *really* fake one
 fail_resp = Mock(side_effect=gssapi.exceptions.GSSError(0, 0))
 
-gssflags = [gssapi.RequirementFlag.out_of_sequence_detection]
+gssflags = []
 mutflags = gssflags + [gssapi.RequirementFlag.mutual_authentication]
 gssdelegflags = gssflags + [gssapi.RequirementFlag.delegate_to_peer]
 


### PR DESCRIPTION
SPNEGO over HTTP does not use any message wrapping, therefore requesting
out of sequence detection doesn't make sense.

This fixes #38