### PR TITLE
Set `SanitizedResponse` content to bytes instead of string

### DIFF
--- a/requests_gssapi/gssapi_.py
+++ b/requests_gssapi/gssapi_.py
@@ -54,7 +54,7 @@ class SanitizedResponse(Response):
         self.connection = response.connection
         self._content_consumed = True
 
-        self._content = ""
+        self._content = b""
         self.cookies = cookiejar_from_dict({})
         self.headers = CaseInsensitiveDict()
         self.headers['content-length'] = '0'

--- a/test_requests_gssapi.py
+++ b/test_requests_gssapi.py
@@ -164,7 +164,7 @@ class GSSAPITestCase(unittest.TestCase):
             response.headers = {'www-authenticate': b64_negotiate_token}
             response.status_code = 401
             response.connection = connection
-            response._content = ""
+            response._content = b""
             response.raw = raw
             auth = requests_gssapi.HTTPKerberosAuth()
             r = auth.authenticate_user(response)
@@ -201,7 +201,7 @@ class GSSAPITestCase(unittest.TestCase):
             response.headers = {'www-authenticate': b64_negotiate_token}
             response.status_code = 401
             response.connection = connection
-            response._content = ""
+            response._content = b""
             response.raw = raw
             auth = requests_gssapi.HTTPKerberosAuth()
             r = auth.handle_401(response)
@@ -375,7 +375,8 @@ class GSSAPITestCase(unittest.TestCase):
             self.assertEqual(r.url, response_500.url)
             self.assertEqual(r.reason, response_500.reason)
             self.assertEqual(r.connection, response_500.connection)
-            self.assertEqual(r.content, '')
+            self.assertEqual(r.content, b"")
+            self.assertEqual(r.text, "")
             self.assertNotEqual(r.cookies, response_500.cookies)
 
             self.assertFalse(fail_resp.called)
@@ -436,7 +437,7 @@ class GSSAPITestCase(unittest.TestCase):
             response.headers = {'www-authenticate': b64_negotiate_token}
             response.status_code = 401
             response.connection = connection
-            response._content = ""
+            response._content = b""
             response.raw = raw
 
             auth = requests_gssapi.HTTPKerberosAuth()
@@ -482,7 +483,7 @@ class GSSAPITestCase(unittest.TestCase):
             response.headers = {'www-authenticate': b64_negotiate_token}
             response.status_code = 401
             response.connection = connection
-            response._content = ""
+            response._content = b""
             response.raw = raw
 
             auth = requests_gssapi.HTTPKerberosAuth()
@@ -534,7 +535,7 @@ class GSSAPITestCase(unittest.TestCase):
             response.headers = {'www-authenticate': b64_negotiate_token}
             response.status_code = 401
             response.connection = connection
-            response._content = ""
+            response._content = b""
             response.raw = raw
             auth = requests_gssapi.HTTPKerberosAuth(service="HTTP",
                                                     delegate=True)


### PR DESCRIPTION
The `content` property of a `Response` object is expected to always be bytes (the `text` property should be a string).

This change fixes an issue where consumers of the library that were returned a `SanitizedResponse` object could fail because they expected the `content` attribute of it to be bytes instead of a string.