### PR TITLE
Support GSSAPI channel bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,3 +241,26 @@ If you are having difficulty we suggest you configure logging. Issues with the
 underlying GSSAPI libraries will be made apparent. Additionally, copious debug
 information is made available which may assist in troubleshooting if you
 increase your log level all the way up to debug.
+
+Channel Bindings
+----------------
+
+Optional simplified support for channel bindings is available, but limited to
+the 'tls-server-end-point' bindings type (manual construction of different
+channel bindings can be achieved using the raw API). When requesting this kind
+of bindings python-cryptography must be available as request-gssapi will try
+to import its x509 module to process the peer certificate.
+
+.. code-block:: python
+
+    >>> import requests
+    >>> from requests_gssapi import HTTPSPNEGOAuth
+    >>> gssapi_auth = HTTPSPNEGOAuth(channel_bindings='tls-server-end-point')
+    >>> r = requests.get("https://windows.example.org/wsman", auth=gssapi_auth)
+    ...
+
+It should be noted that this will not work for connections that are closed on
+the initial authentication failure. If the connection is closed, the peer
+certificate may be purged from internal data structures and is not available
+to extract the ``tls-server-end-point`` value required to complete
+authentication.

--- a/tests/test_requests_gssapi.py
+++ b/tests/test_requests_gssapi.py
@@ -98,7 +98,12 @@ class GSSAPITestCase(unittest.TestCase):
             auth = requests_gssapi.HTTPKerberosAuth()
             self.assertEqual(auth.generate_request_header(response, host), b64_negotiate_response)
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), creds=None, mech=SPNEGO, flags=gssflags, usage="initiate"
+                name=gssapi_sname("HTTP@www.example.org"),
+                creds=None,
+                mech=SPNEGO,
+                flags=gssflags,
+                usage="initiate",
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -113,7 +118,12 @@ class GSSAPITestCase(unittest.TestCase):
                 requests_gssapi.exceptions.SPNEGOExchangeError, auth.generate_request_header, response, host
             )
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), usage="initiate", flags=gssflags, creds=None, mech=SPNEGO
+                name=gssapi_sname("HTTP@www.example.org"),
+                usage="initiate",
+                flags=gssflags,
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
 
     def test_generate_request_header_step_error(self):
@@ -127,7 +137,12 @@ class GSSAPITestCase(unittest.TestCase):
                 requests_gssapi.exceptions.SPNEGOExchangeError, auth.generate_request_header, response, host
             )
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), usage="initiate", flags=gssflags, creds=None, mech=SPNEGO
+                name=gssapi_sname("HTTP@www.example.org"),
+                usage="initiate",
+                flags=gssflags,
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
             fail_resp.assert_called_with(b"token")
 
@@ -162,7 +177,12 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), flags=gssflags, usage="initiate", creds=None, mech=SPNEGO
+                name=gssapi_sname("HTTP@www.example.org"),
+                flags=gssflags,
+                usage="initiate",
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -197,7 +217,12 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), creds=None, mech=SPNEGO, flags=gssflags, usage="initiate"
+                name=gssapi_sname("HTTP@www.example.org"),
+                creds=None,
+                mech=SPNEGO,
+                flags=gssflags,
+                usage="initiate",
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -402,7 +427,12 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), usage="initiate", flags=gssflags, creds=None, mech=SPNEGO
+                name=gssapi_sname("HTTP@www.example.org"),
+                usage="initiate",
+                flags=gssflags,
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -443,7 +473,12 @@ class GSSAPITestCase(unittest.TestCase):
             connection.send.assert_called_with(request)
             raw.release_conn.assert_called_with()
             fake_init.assert_called_with(
-                name=gssapi_sname("HTTP@www.example.org"), usage="initiate", flags=gssflags, creds=None, mech=SPNEGO
+                name=gssapi_sname("HTTP@www.example.org"),
+                usage="initiate",
+                flags=gssflags,
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -456,7 +491,12 @@ class GSSAPITestCase(unittest.TestCase):
             auth = requests_gssapi.HTTPKerberosAuth(service="barfoo")
             auth.generate_request_header(response, host),
             fake_init.assert_called_with(
-                name=gssapi_sname("barfoo@www.example.org"), usage="initiate", flags=gssflags, creds=None, mech=SPNEGO
+                name=gssapi_sname("barfoo@www.example.org"),
+                usage="initiate",
+                flags=gssflags,
+                creds=None,
+                mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -496,6 +536,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssdelegflags,
                 creds=None,
                 mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -522,6 +563,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssflags,
                 creds=b"fake creds",
                 mech=SPNEGO,
+                channel_bindings=None,
             )
 
     def test_realm_override(self):
@@ -538,6 +580,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssflags,
                 creds=None,
                 mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -569,6 +612,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssflags,
                 creds=b"fake creds",
                 mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -589,6 +633,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssflags,
                 creds=None,
                 mech=b"fake mech",
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 
@@ -606,6 +651,7 @@ class GSSAPITestCase(unittest.TestCase):
                 flags=gssflags,
                 creds=None,
                 mech=SPNEGO,
+                channel_bindings=None,
             )
             fake_resp.assert_called_with(b"token")
 


### PR DESCRIPTION
This change adds support for GSSAPI channel bindings, which helps to protect against man-in-the-middle relay attacks by tying the authentication to the underlying secure channel.

A `channel_bindings` parameter is added to `HTTPSPNEGOAuth`. When set to 'tls- server-end-point', the server's TLS certificate is retrieved from the socket, hashed, and used to create the GSSAPI channel bindings.

This feature requires the `cryptography` library as an optional dependency. If it's not available, channel bindings cannot be used and a warning is logged.

Fixes #56 